### PR TITLE
Add default to not include port, fixes libsyn requests

### DIFF
--- a/config/initializers/excon.rb
+++ b/config/initializers/excon.rb
@@ -1,0 +1,3 @@
+require 'excon'
+
+Excon.defaults[:omit_default_port] = true


### PR DESCRIPTION
I'm seeing a different result for Excon requests and curl without this setting - it it failing to get the latest episode of TMP.
