### PR TITLE
Job error handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER PRX <sysadmin@prx.org>
 
 RUN apk update && apk --update add ca-certificates ruby ruby-irb ruby-json ruby-rake \
     ruby-bigdecimal ruby-io-console libstdc++ tzdata postgresql-client nodejs \
-    linux-headers libc-dev zlib libxml2 libxslt libffi
+    linux-headers libc-dev zlib libxml2 libxslt libffi less
 
 ENV TINI_VERSION v0.9.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static /tini

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ docker-compose run crier test
 # Guard
 docker-compose run crier guard
 
+# Console
+docker-compose run crier console
+
 # Run the web, worker, and db
 docker-compose up
 ```

--- a/app/jobs/sync_feed_job.rb
+++ b/app/jobs/sync_feed_job.rb
@@ -4,16 +4,13 @@ class SyncFeedJob < ActiveJob::Base
 
   def perform(feed, reschedule = false)
     ActiveRecord::Base.connection_pool.with_connection do
-      begin
-        if feed.nil? || feed.deleted?
-          reschedule = false
-        else
-          feed.sync
-        end
-      ensure
-        if reschedule && feed
-          SyncFeedJob.set(wait: feed.sync_interval).perform_later(feed, true)
-        end
+      if feed.nil? || feed.deleted?
+        reschedule = false
+      else
+        feed.sync
+      end
+      if reschedule && feed
+        SyncFeedJob.set(wait: feed.sync_interval).perform_later(feed, true)
       end
     end
   end

--- a/bin/application
+++ b/bin/application
@@ -25,6 +25,8 @@ ApplicationRun () {
   elif [ "$PROCESS" = "web" ] ; then
     ApplicationUpdate
     CMD="bundle exec puma -C config/puma.rb"
+  elif [ "$PROCESS" = "console" ] ; then
+    CMD="bundle exec rails console"
   elif [ "$PROCESS" = "worker" ] ; then
     ApplicationUpdate
     CMD="bundle exec shoryuken --verbose --rails --config config/shoryuken.yml"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ crier:
   environment:
     VIRTUAL_HOST: crier.prx.docker
 worker:
-  image: crierprxorg_app
+  image: crierprxorg_crier
   volumes:
     - .:/app
   env_file:

--- a/env-example
+++ b/env-example
@@ -15,3 +15,5 @@ SECRET_KEY_BASE=thisisnotasecret
 SECRET_TOKEN=thisisnotasecret
 
 NEW_RELIC_KEY=
+
+RAILS_ENV=development

--- a/test/jobs/sync_feed_job_test.rb
+++ b/test/jobs/sync_feed_job_test.rb
@@ -7,19 +7,51 @@ describe SyncFeedJob do
       to_return(status: 200, body: test_file('/fixtures/99percentinvisible.xml'), headers: {})
     stub_head_requests(/http:\/\/.*\.podtrac.com\/.*/)
   }
-  let(:feed) { Feed.create!(feed_url: 'http://feeds.99percentinvisible.org/99percentinvisible') }
+  let(:job) { SyncFeedJob.new }
+  let(:feed) do
+    f = Feed.create!(feed_url: 'http://feeds.99percentinvisible.org/99percentinvisible')
+    clear_enqueued_jobs # clear the initial sync
+    f
+  end
 
-  it 'sync feed by id' do
-    SyncFeedJob.new.perform(feed, true)
+  it 'syncs and reschedules feeds' do
+    assert_enqueued_jobs 0
+    feed.responses.count.must_equal 0
+    job.perform(feed, true)
+    assert_enqueued_jobs 1
+    feed.responses.count.must_equal 1
+  end
+
+  it 'does not sync or reschedule deleted feeds' do
+    feed.destroy!
+    assert_enqueued_jobs 0
+    feed.responses.count.must_equal 0
+    job.perform(feed, true)
+    assert_enqueued_jobs 0
+    feed.responses.count.must_equal 0
   end
 
   it 'does not schedule jobs if unschedule false' do
-    SyncFeedJob.new.perform(feed, false)
+    assert_enqueued_jobs 0
+    feed.responses.count.must_equal 0
+    job.perform(feed, false)
+    assert_enqueued_jobs 0
+    feed.responses.count.must_equal 1
   end
 
-  it 'does not schedule jobs with a deleted feed' do
-    feed.stub(:deleted?, true) do
-      SyncFeedJob.new.perform(feed, true)
+  it 'does not reschedule jobs that throw an error' do
+    raises_exception = -> { raise ArgumentError.new }
+    feed.stub(:sync, raises_exception) do
+      assert_enqueued_jobs 0
+      feed.responses.count.must_equal 0
+      begin
+        job.perform(feed, true)
+        raise 'should not have gotten here'
+      rescue ArgumentError => e
+        assert_enqueued_jobs 0
+        feed.responses.count.must_equal 0
+      end
     end
   end
+
 end


### PR DESCRIPTION
Currently, we're not catching thrown errors during `SyncFeedJob`.  But we are `ensure`-ing that we'll reschedule them.  Since Shoryuken isn't going to delete the SQS message when you throw an error, this results in a duplicate message every time an error is thrown.  (The initial message is released after an hour).  This exponentially grows - saw this stack up 2.6 million duplicate messages in production.

With these changes, a thrown error doesn't reschedule the job for 10-minutes later.  Instead, it just leaves the message undeleted, and it will be released an hour later.

Also need to make sure we're reporting these errors somewhere (probably New Relic).