### PR TITLE
Use ruby alpine docker base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
-FROM alpine:3.4
+FROM ruby:2.3-alpine
 
 MAINTAINER PRX <sysadmin@prx.org>
 
-RUN apk update && apk --update add ca-certificates ruby ruby-irb ruby-json ruby-rake \
-    ruby-bigdecimal ruby-io-console libstdc++ tzdata postgresql-client nodejs \
-    linux-headers libc-dev zlib libxml2 libxslt libffi less
+RUN apk update && apk --update add \
+    ca-certificates \
+    tzdata \
+    linux-headers \
+    libxml2 \
+    libxslt \
+    postgresql-client \
+    nodejs \
+    less
 
 ENV TINI_VERSION v0.9.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static /tini
@@ -17,10 +23,17 @@ WORKDIR $APP_HOME
 ADD Gemfile ./
 ADD Gemfile.lock ./
 
-RUN apk --update add --virtual build-dependencies build-base curl-dev ruby-dev openssl-dev \
-    postgresql-dev zlib-dev libxml2-dev libxslt-dev libffi-dev libgcrypt-dev && \
-    gem install -N bundler && \
-    cd $APP_HOME ; \
+RUN apk --update add --virtual build-dependencies \
+    build-base \
+    curl-dev \
+    openssl-dev \
+    postgresql-dev \
+    zlib-dev \
+    libxml2-dev \
+    libxslt-dev \
+    libffi-dev \
+    libgcrypt-dev && \
+    cd $APP_HOME && \
     bundle config --global build.nokogiri  "--use-system-libraries" && \
     bundle config --global build.nokogumbo "--use-system-libraries" && \
     bundle config --global build.ffi  "--use-system-libraries" && \

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -10,6 +10,9 @@ Rails.application.configure do
   # Do not eager load code on boot.
   config.eager_load = false
 
+  config.logger = Logger.new(STDOUT)
+  config.log_level = :debug
+
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false


### PR DESCRIPTION
This fixes the issue where irb was creating seg faults by using the ruby alpine image that has a built from src version of ruby 2.3

https://bugs.alpinelinux.org/issues/4986
https://github.com/docker-library/ruby/issues/75